### PR TITLE
Fix alignment of penguin mail logo

### DIFF
--- a/frontend/src/components/layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar/Sidebar.tsx
@@ -67,7 +67,7 @@ export function Sidebar() {
               {/* "Penguin Mail" text */}
               <text
                 x="28"
-                y="19"
+                y="21.3"
                 fill="currentColor"
                 fontFamily="var(--font-family-sans)"
                 fontSize="16"


### PR DESCRIPTION
While working on implementing email send, I "fixed" the misalignment between the penguin logo and the "penguin mail" text at the top of the user interface.